### PR TITLE
fix: typo in `ReferenceOptions` name

### DIFF
--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1643,7 +1643,7 @@ pub struct ServerCapabilities {
 
     /// The server provides find references support.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub references_provider: Option<OneOf<bool, ReferencesOptions>>,
+    pub references_provider: Option<OneOf<bool, ReferenceOptions>>,
 
     /// The server provides document highlight support.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1877,7 +1877,7 @@ pub struct DocumentSymbolRegistrationOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ReferencesOptions {
+pub struct ReferenceOptions {
     #[serde(flatten)]
     pub work_done_progress_options: WorkDoneProgressOptions,
 }


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#referenceOptions