### PR TITLE
feat: primitive type conversions for WorkspaceSymbolResponse

### DIFF
--- a/src/lsp/workspace_symbols.rs
+++ b/src/lsp/workspace_symbols.rs
@@ -103,3 +103,15 @@ pub enum WorkspaceSymbolResponse {
     Flat(Vec<SymbolInformation>),
     Nested(Vec<WorkspaceSymbol>),
 }
+
+impl From<Vec<SymbolInformation>> for WorkspaceSymbolResponse {
+    fn from(info: Vec<SymbolInformation>) -> Self {
+        Self::Flat(info)
+    }
+}
+
+impl From<Vec<WorkspaceSymbol>> for WorkspaceSymbolResponse {
+    fn from(symbols: Vec<WorkspaceSymbol>) -> Self {
+        Self::Nested(symbols)
+    }
+}


### PR DESCRIPTION
The document symbol response type has these helpers, so we may as well add them here as well.