### PR TITLE
chore: address some clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ dbg_macro = "warn"
 todo = "warn"
 
 # We mirror LSP specification documentation
-missing_const_for_fn = "allow"
+doc_markdown = "allow"
 too_long_first_doc_paragraph = "allow"

--- a/src/lsp/basic.rs
+++ b/src/lsp/basic.rs
@@ -563,7 +563,7 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         range: Range,
         severity: Option<DiagnosticSeverity>,
         code: Option<NumberOrString>,
@@ -587,7 +587,7 @@ impl Diagnostic {
     }
 
     #[must_use]
-    pub fn new_simple(range: Range, message: String) -> Self {
+    pub const fn new_simple(range: Range, message: String) -> Self {
         #[cfg(not(feature = "proposed"))]
         {
             Self::new(range, None, None, None, message, None, None)
@@ -599,7 +599,7 @@ impl Diagnostic {
     }
 
     #[must_use]
-    pub fn new_with_code_number(
+    pub const fn new_with_code_number(
         range: Range,
         severity: DiagnosticSeverity,
         code_number: i32,


### PR DESCRIPTION
This commit allows doc comments to not wrap types in backticks (since the descriptions come directly from the spec, which don't always add them) and makes the diagnostic constructors `const` where possible. (Let me know if this last bit was intentional, and I can revert this change.)