### PR TITLE
fix: remove duplicated DocumentSymbol.

### DIFF
--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1668,43 +1668,6 @@ impl From<i32> for NumberOrString {
     }
 }
 
-/// Represents programming constructs like variables, classes, interfaces etc.
-///
-/// that appear in a document. Document symbols can be hierarchical and they have two ranges:
-/// one that encloses its definition and one that points to its most interesting range,
-/// e.g. the range of an identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DocumentSymbol {
-    /// The name of this symbol.
-    pub name: String,
-    /// More detail for this symbol, e.g the signature of a function. If not provided the
-    /// name is used.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
-    /// The kind of this symbol.
-    pub kind: SymbolKind,
-    /// Tags for this completion item.
-    ///
-    /// @since 3.15.0
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<Vec<SymbolTag>>,
-    /// Indicates if this symbol is deprecated.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[deprecated(note = "Use tags instead")]
-    pub deprecated: Option<bool>,
-    /// The range enclosing this symbol not including leading/trailing whitespace but everything else
-    /// like comments. This information is typically used to determine if the the clients cursor is
-    /// inside the symbol to reveal in the symbol in the UI.
-    pub range: Range,
-    /// The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-    /// Must be contained by the the `range`.
-    pub selection_range: Range,
-    /// Children of this symbol, e.g. properties of a class.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<DocumentSymbol>>,
-}
-
 /// A symbol kind.
 #[derive(Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(transparent)]


### PR DESCRIPTION
fix: https://github.com/tombi-toml/tombi/pull/845

DocumentSymbol defined on the `src/lsp/document_symbols.rs` and `src/lsp/mod.rs`.
